### PR TITLE
 Created MIGRATOR_HOME

### DIFF
--- a/src/main/java/com/openmrs/migrator/MigratorApplication.java
+++ b/src/main/java/com/openmrs/migrator/MigratorApplication.java
@@ -20,6 +20,10 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class MigratorApplication implements CommandLineRunner {
 
+  private static final String MIGRATOR_HOME = "MIGRATOR_HOME";
+
+  private static final String USER_DIR = "user.dir";
+
   private static Logger LOG = LoggerFactory.getLogger(MigratorApplication.class);
 
   private final PDIService pdiService;
@@ -56,12 +60,13 @@ public class MigratorApplication implements CommandLineRunner {
   public void run(String... args) throws SettingsException, IOException {
     LOG.info("EXECUTING : command line runner");
 
+    setMigratorHome();
+
     for (int i = 0; i < args.length; ++i) {
       LOG.info("args[{}]: {}", i, args[i]);
     }
 
     if (args.length > 0 && "setup".equals(args[0])) {
-
       executeSetupCommand();
     }
 
@@ -103,5 +108,14 @@ public class MigratorApplication implements CommandLineRunner {
 
     bootstrapService.createDirectoryStructure(dirList);
     bootstrapService.populateDefaultResources(pdiFiles);
+  }
+
+  private void setMigratorHome() {
+    String home = System.getProperty(MIGRATOR_HOME);
+    if (home == null) {
+      String userDir = System.getProperty(USER_DIR);
+      System.setProperty(MIGRATOR_HOME, userDir);
+    }
+    LOG.info("MIGRATOR_HOME={}", System.getProperty(MIGRATOR_HOME));
   }
 }

--- a/src/main/resources/pdiresources/jobs/merge-patient-job.kjb
+++ b/src/main/resources/pdiresources/jobs/merge-patient-job.kjb
@@ -315,7 +315,7 @@
       <attributes/>
       <specification_method>filename</specification_method>
       <trans_object_id/>
-      <filename>src/main/resources/pdiresources/transformations/merge-patient.ktr</filename>
+      <filename>${MIGRATOR_HOME}/pdiresources/transformations/merge-patient.ktr</filename>
       <transname/>
       <arg_from_previous>N</arg_from_previous>
       <params_from_previous>N</params_from_previous>

--- a/src/main/resources/pdiresources/jobs/validations.kjb
+++ b/src/main/resources/pdiresources/jobs/validations.kjb
@@ -294,7 +294,7 @@
       <attributes/>
       <specification_method>filename</specification_method>
       <trans_object_id/>
-      <filename>src/main/resources/pdiresources/transformations/validate-concepts.ktr</filename>
+      <filename>${MIGRATOR_HOME}/pdiresources/transformations/validate-concepts.ktr</filename>
       <transname/>
       <arg_from_previous>N</arg_from_previous>
       <params_from_previous>N</params_from_previous>
@@ -332,7 +332,7 @@
       <attributes/>
       <specification_method>filename</specification_method>
       <trans_object_id/>
-      <filename>src/main/resources/pdiresources/transformations/validate-person-attribute-types.ktr</filename>
+      <filename>${MIGRATOR_HOME}/pdiresources/transformations/validate-person-attribute-types.ktr</filename>
       <transname/>
       <arg_from_previous>N</arg_from_previous>
       <params_from_previous>N</params_from_previous>
@@ -392,7 +392,7 @@
       <attributes/>
       <specification_method>filename</specification_method>
       <trans_object_id/>
-      <filename>src/main/resources/pdiresources/transformations/validate-relationship-types.ktr</filename>
+      <filename>${MIGRATOR_HOME}/pdiresources/transformations/validate-relationship-types.ktr</filename>
       <transname/>
       <arg_from_previous>N</arg_from_previous>
       <params_from_previous>N</params_from_previous>
@@ -430,7 +430,7 @@
       <attributes/>
       <specification_method>filename</specification_method>
       <trans_object_id/>
-      <filename>src/main/resources/pdiresources/transformations/validate-roles.ktr</filename>
+      <filename>${MIGRATOR_HOME}/pdiresources/transformations/validate-roles.ktr</filename>
       <transname/>
       <arg_from_previous>N</arg_from_previous>
       <params_from_previous>N</params_from_previous>
@@ -468,7 +468,7 @@
       <attributes/>
       <specification_method>filename</specification_method>
       <trans_object_id/>
-      <filename>src/main/resources/pdiresources/transformations/validate-encounter-types.ktr</filename>
+      <filename>${MIGRATOR_HOME}/pdiresources/transformations/validate-encounter-types.ktr</filename>
       <transname/>
       <arg_from_previous>N</arg_from_previous>
       <params_from_previous>N</params_from_previous>
@@ -506,7 +506,7 @@
       <attributes/>
       <specification_method>filename</specification_method>
       <trans_object_id/>
-      <filename>src/main/resources/pdiresources/transformations/validate-forms.ktr</filename>
+      <filename>${MIGRATOR_HOME}/pdiresources/transformations/validate-forms.ktr</filename>
       <transname/>
       <arg_from_previous>N</arg_from_previous>
       <params_from_previous>N</params_from_previous>
@@ -544,7 +544,7 @@
       <attributes/>
       <specification_method>filename</specification_method>
       <trans_object_id/>
-      <filename>src/main/resources/pdiresources/transformations/validate-visit-types.ktr</filename>
+      <filename>${MIGRATOR_HOME}/pdiresources/transformations/validate-visit-types.ktr</filename>
       <transname/>
       <arg_from_previous>N</arg_from_previous>
       <params_from_previous>N</params_from_previous>
@@ -582,7 +582,7 @@
       <attributes/>
       <specification_method>filename</specification_method>
       <trans_object_id/>
-      <filename>src/main/resources/pdiresources/transformations/validate-visit-attribute-types.ktr</filename>
+      <filename>${MIGRATOR_HOME}/pdiresources/transformations/validate-visit-attribute-types.ktr</filename>
       <transname/>
       <arg_from_previous>N</arg_from_previous>
       <params_from_previous>N</params_from_previous>
@@ -620,7 +620,7 @@
       <attributes/>
       <specification_method>filename</specification_method>
       <trans_object_id/>
-      <filename>src/main/resources/pdiresources/transformations/validate-patient-identifier-types.ktr</filename>
+      <filename>${MIGRATOR_HOME}/pdiresources/transformations/validate-patient-identifier-types.ktr</filename>
       <transname/>
       <arg_from_previous>N</arg_from_previous>
       <params_from_previous>N</params_from_previous>
@@ -658,7 +658,7 @@
       <attributes/>
       <specification_method>filename</specification_method>
       <trans_object_id/>
-      <filename>src/main/resources/pdiresources/transformations/validate-programs.ktr</filename>
+      <filename>${MIGRATOR_HOME}/pdiresources/transformations/validate-programs.ktr</filename>
       <transname/>
       <arg_from_previous>N</arg_from_previous>
       <params_from_previous>N</params_from_previous>
@@ -696,7 +696,7 @@
       <attributes/>
       <specification_method>filename</specification_method>
       <trans_object_id/>
-      <filename>src/main/resources/pdiresources/transformations/validate-program-workflows.ktr</filename>
+      <filename>${MIGRATOR_HOME}/pdiresources/transformations/validate-program-workflows.ktr</filename>
       <transname/>
       <arg_from_previous>N</arg_from_previous>
       <params_from_previous>N</params_from_previous>
@@ -734,7 +734,7 @@
       <attributes/>
       <specification_method>filename</specification_method>
       <trans_object_id/>
-      <filename>src/main/resources/pdiresources/transformations/validate-program-workflow-states.ktr</filename>
+      <filename>${MIGRATOR_HOME}/pdiresources/transformations/validate-program-workflow-states.ktr</filename>
       <transname/>
       <arg_from_previous>N</arg_from_previous>
       <params_from_previous>N</params_from_previous>
@@ -772,7 +772,7 @@
       <attributes/>
       <specification_method>filename</specification_method>
       <trans_object_id/>
-      <filename>src/main/resources/pdiresources/transformations/validate-order-types.ktr</filename>
+      <filename>${MIGRATOR_HOME}/pdiresources/transformations/validate-order-types.ktr</filename>
       <transname/>
       <arg_from_previous>N</arg_from_previous>
       <params_from_previous>N</params_from_previous>
@@ -810,7 +810,7 @@
       <attributes/>
       <specification_method>filename</specification_method>
       <trans_object_id/>
-      <filename>src/main/resources/pdiresources/transformations/validate-scheduler-task-config.ktr</filename>
+      <filename>${MIGRATOR_HOME}/pdiresources/transformations/validate-scheduler-task-config.ktr</filename>
       <transname/>
       <arg_from_previous>N</arg_from_previous>
       <params_from_previous>N</params_from_previous>

--- a/src/main/resources/pdiresources/transformations/validate-concepts.ktr
+++ b/src/main/resources/pdiresources/transformations/validate-concepts.ktr
@@ -589,7 +589,7 @@
       <method>none</method>
       <schema_name/>
     </partitioning>
-    <filename>src/main/resources/pdiresources/config/concept.csv</filename>
+    <filename>${MIGRATOR_HOME}/config/concept.csv</filename>
     <filename_field/>
     <rownum_field/>
     <include_filename>N</include_filename>

--- a/src/main/resources/pdiresources/transformations/validate-encounter-types.ktr
+++ b/src/main/resources/pdiresources/transformations/validate-encounter-types.ktr
@@ -589,7 +589,7 @@
       <method>none</method>
       <schema_name/>
     </partitioning>
-    <filename>src/main/resources/pdiresources/config/encounter_type.csv</filename>
+    <filename>${MIGRATOR_HOME}/config/encounter_type.csv</filename>
     <filename_field/>
     <rownum_field/>
     <include_filename>N</include_filename>

--- a/src/main/resources/pdiresources/transformations/validate-forms.ktr
+++ b/src/main/resources/pdiresources/transformations/validate-forms.ktr
@@ -589,7 +589,7 @@
       <method>none</method>
       <schema_name/>
     </partitioning>
-    <filename>src/main/resources/pdiresources/config/form.csv</filename>
+    <filename>${MIGRATOR_HOME}/config/form.csv</filename>
     <filename_field/>
     <rownum_field/>
     <include_filename>N</include_filename>

--- a/src/main/resources/pdiresources/transformations/validate-order-types.ktr
+++ b/src/main/resources/pdiresources/transformations/validate-order-types.ktr
@@ -589,7 +589,7 @@
       <method>none</method>
       <schema_name/>
     </partitioning>
-    <filename>src/main/resources/pdiresources/config/order_type.csv</filename>
+    <filename>${MIGRATOR_HOME}/config/order_type.csv</filename>
     <filename_field/>
     <rownum_field/>
     <include_filename>N</include_filename>

--- a/src/main/resources/pdiresources/transformations/validate-patient-identifier-types.ktr
+++ b/src/main/resources/pdiresources/transformations/validate-patient-identifier-types.ktr
@@ -589,7 +589,7 @@
       <method>none</method>
       <schema_name/>
     </partitioning>
-    <filename>src/main/resources/pdiresources/config/patient_identifier_type.csv</filename>
+    <filename>${MIGRATOR_HOME}/config/patient_identifier_type.csv</filename>
     <filename_field/>
     <rownum_field/>
     <include_filename>N</include_filename>

--- a/src/main/resources/pdiresources/transformations/validate-person-attribute-types.ktr
+++ b/src/main/resources/pdiresources/transformations/validate-person-attribute-types.ktr
@@ -589,7 +589,7 @@
       <method>none</method>
       <schema_name/>
     </partitioning>
-    <filename>src/main/resources/pdiresources/config/person_attribute_type.csv</filename>
+    <filename>${MIGRATOR_HOME}/config/person_attribute_type.csv</filename>
     <filename_field/>
     <rownum_field/>
     <include_filename>N</include_filename>

--- a/src/main/resources/pdiresources/transformations/validate-program-workflow-states.ktr
+++ b/src/main/resources/pdiresources/transformations/validate-program-workflow-states.ktr
@@ -589,7 +589,7 @@
       <method>none</method>
       <schema_name/>
     </partitioning>
-    <filename>src/main/resources/pdiresources/config/program_workflow_state.csv</filename>
+    <filename>${MIGRATOR_HOME}/config/program_workflow_state.csv</filename>
     <filename_field/>
     <rownum_field/>
     <include_filename>N</include_filename>

--- a/src/main/resources/pdiresources/transformations/validate-program-workflows.ktr
+++ b/src/main/resources/pdiresources/transformations/validate-program-workflows.ktr
@@ -589,7 +589,7 @@
       <method>none</method>
       <schema_name/>
     </partitioning>
-    <filename>src/main/resources/pdiresources/config/program_workflow.csv</filename>
+    <filename>${MIGRATOR_HOME}/config/program_workflow.csv</filename>
     <filename_field/>
     <rownum_field/>
     <include_filename>N</include_filename>

--- a/src/main/resources/pdiresources/transformations/validate-programs.ktr
+++ b/src/main/resources/pdiresources/transformations/validate-programs.ktr
@@ -589,7 +589,7 @@
       <method>none</method>
       <schema_name/>
     </partitioning>
-    <filename>src/main/resources/pdiresources/config/program.csv</filename>
+    <filename>${MIGRATOR_HOME}/config/program.csv</filename>
     <filename_field/>
     <rownum_field/>
     <include_filename>N</include_filename>

--- a/src/main/resources/pdiresources/transformations/validate-relationship-types.ktr
+++ b/src/main/resources/pdiresources/transformations/validate-relationship-types.ktr
@@ -589,7 +589,7 @@
       <method>none</method>
       <schema_name/>
     </partitioning>
-    <filename>src/main/resources/pdiresources/config/relationship_type.csv</filename>
+    <filename>${MIGRATOR_HOME}/config/relationship_type.csv</filename>
     <filename_field/>
     <rownum_field/>
     <include_filename>N</include_filename>

--- a/src/main/resources/pdiresources/transformations/validate-roles.ktr
+++ b/src/main/resources/pdiresources/transformations/validate-roles.ktr
@@ -589,7 +589,7 @@
       <method>none</method>
       <schema_name/>
     </partitioning>
-    <filename>src/main/resources/pdiresources/config/role.csv</filename>
+    <filename>${MIGRATOR_HOME}/config/role.csv</filename>
     <filename_field/>
     <rownum_field/>
     <include_filename>N</include_filename>

--- a/src/main/resources/pdiresources/transformations/validate-scheduler-task-config.ktr
+++ b/src/main/resources/pdiresources/transformations/validate-scheduler-task-config.ktr
@@ -589,7 +589,7 @@
       <method>none</method>
       <schema_name/>
     </partitioning>
-    <filename>src/main/resources/pdiresources/config/scheduler_task_config.csv</filename>
+    <filename>${MIGRATOR_HOME}/config/scheduler_task_config.csv</filename>
     <filename_field/>
     <rownum_field/>
     <include_filename>N</include_filename>

--- a/src/main/resources/pdiresources/transformations/validate-visit-attribute-types.ktr
+++ b/src/main/resources/pdiresources/transformations/validate-visit-attribute-types.ktr
@@ -589,7 +589,7 @@
       <method>none</method>
       <schema_name/>
     </partitioning>
-    <filename>src/main/resources/pdiresources/config/visit_attribute_type.csv</filename>
+    <filename>${MIGRATOR_HOME}/config/visit_attribute_type.csv</filename>
     <filename_field/>
     <rownum_field/>
     <include_filename>N</include_filename>

--- a/src/main/resources/pdiresources/transformations/validate-visit-types.ktr
+++ b/src/main/resources/pdiresources/transformations/validate-visit-types.ktr
@@ -589,7 +589,7 @@
       <method>none</method>
       <schema_name/>
     </partitioning>
-    <filename>src/main/resources/pdiresources/config/visit_type.csv</filename>
+    <filename>${MIGRATOR_HOME}/config/visit_type.csv</filename>
     <filename_field/>
     <rownum_field/>
     <include_filename>N</include_filename>

--- a/src/test/java/com/openmrs/migrator/integration/PDIServiceTest.java
+++ b/src/test/java/com/openmrs/migrator/integration/PDIServiceTest.java
@@ -1,0 +1,5 @@
+package com.openmrs.migrator.integration;
+
+import static org.junit.Assert.*;
+
+public class PDIServiceTest {}

--- a/src/test/java/com/openmrs/migrator/integration/PDIServiceTest.java
+++ b/src/test/java/com/openmrs/migrator/integration/PDIServiceTest.java
@@ -1,5 +1,0 @@
-package com.openmrs.migrator.integration;
-
-import static org.junit.Assert.*;
-
-public class PDIServiceTest {}

--- a/src/test/java/com/openmrs/migrator/unit/MigratorApplicationTest.java
+++ b/src/test/java/com/openmrs/migrator/unit/MigratorApplicationTest.java
@@ -1,0 +1,42 @@
+package com.openmrs.migrator.unit;
+
+import static org.junit.Assert.assertEquals;
+
+import com.openmrs.migrator.MigratorApplication;
+import com.openmrs.migrator.core.exceptions.SettingsException;
+import java.io.IOException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class MigratorApplicationTest {
+
+  private static final String MIGRATOR_HOME = "MIGRATOR_HOME";
+
+  @Autowired private MigratorApplication migratorApplication;
+
+  @Before
+  public void setUp() {
+    System.clearProperty(MIGRATOR_HOME);
+  }
+
+  @Test
+  public void runShouldSetMigratorHomeVariableIfNotGiven() throws IOException, SettingsException {
+    String userDir = System.getProperty("user.dir");
+    migratorApplication.run();
+    assertEquals(userDir, System.getProperty(MIGRATOR_HOME));
+  }
+
+  @Test
+  public void runShouldNotSetMigratorHomeVariableIfGiven() throws IOException, SettingsException {
+    String dir = "/opt/migrator";
+    System.setProperty(MIGRATOR_HOME, dir);
+    migratorApplication.run();
+    assertEquals(dir, System.getProperty(MIGRATOR_HOME));
+  }
+}


### PR DESCRIPTION
This variable was created to make it possible to use relative paths inside jobs and transformations.

If not specified it will point to where the application is being run from.